### PR TITLE
Fix session fixation

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -131,6 +131,9 @@ class RedisSessionInterface(SessionInterface):
             sid = sid.decode('utf-8', 'strict')
         val = self.redis.get(self.key_prefix + sid)
         if val is not None:
+            if '/user/login' in request.path:
+                sid = self._generate_sid()
+                return self.session_class(sid=sid, permanent=self.permanent)
             try:
                 data = self.serializer.loads(val)
                 return self.session_class(data, sid=sid)
@@ -254,6 +257,9 @@ class MemcachedSessionInterface(SessionInterface):
             full_session_key = full_session_key.encode('utf-8')
         val = self.client.get(full_session_key)
         if val is not None:
+            if '/user/login' in request.path:
+                sid = self._generate_sid()
+                return self.session_class(sid=sid, permanent=self.permanent)
             try:
                 if not PY2:
                     val = want_bytes(val)
@@ -342,6 +348,8 @@ class FileSystemSessionInterface(SessionInterface):
 
         data = self.cache.get(self.key_prefix + sid)
         if data is not None:
+            if '/user/login' in request.path:
+                sid = self._generate_sid()
             return self.session_class(data, sid=sid)
         sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
@@ -425,6 +433,9 @@ class MongoDBSessionInterface(SessionInterface):
             self.store.remove({'id': store_id})
             document = None
         if document is not None:
+            if '/user/login' in request.path:
+                sid = self._generate_sid()
+                return self.session_class(sid=sid, permanent=self.permanent)
             try:
                 val = document['val']
                 data = self.serializer.loads(want_bytes(val))
@@ -535,6 +546,9 @@ class SqlAlchemySessionInterface(SessionInterface):
             self.db.session.commit()
             saved_session = None
         if saved_session:
+            if '/user/login' in request.path:
+                sid = self._generate_sid()
+                return self.session_class(sid=sid, permanent=self.permanent)
             try:
                 val = saved_session.data
                 data = self.serializer.loads(want_bytes(val))

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -136,6 +136,7 @@ class RedisSessionInterface(SessionInterface):
                 return self.session_class(data, sid=sid)
             except:
                 return self.session_class(sid=sid, permanent=self.permanent)
+        sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
@@ -260,6 +261,7 @@ class MemcachedSessionInterface(SessionInterface):
                 return self.session_class(data, sid=sid)
             except:
                 return self.session_class(sid=sid, permanent=self.permanent)
+        sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
@@ -341,6 +343,7 @@ class FileSystemSessionInterface(SessionInterface):
         data = self.cache.get(self.key_prefix + sid)
         if data is not None:
             return self.session_class(data, sid=sid)
+        sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
@@ -428,6 +431,7 @@ class MongoDBSessionInterface(SessionInterface):
                 return self.session_class(data, sid=sid)
             except:
                 return self.session_class(sid=sid, permanent=self.permanent)
+        sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
@@ -537,6 +541,7 @@ class SqlAlchemySessionInterface(SessionInterface):
                 return self.session_class(data, sid=sid)
             except:
                 return self.session_class(sid=sid, permanent=self.permanent)
+        sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):


### PR DESCRIPTION
As an output of the Pentest 2023, we had the following vulnerability:

Vulnerability type description:
Session Fixation is an attack that permits an attacker to hijack a valid user session. The attack explores a limitation in the way the web application manages the session ID, more specifically the vulnerable web application. When authenticating a user, it doesn’t assign a new session ID, making it possible to use an existent session ID. The attack consists of obtaining a valid session ID (e.g. by connecting to the application), inducing a user to authenticate himself with that session ID, and then hijacking the user-validated session by the knowledge of the used session ID. The attacker has to provide a legitimate Web application session ID and try to make the victim’s browser use it.
The session fixation attack is a class of Session Hijacking, which steals the established session between the client and the Web Server after the user logs in. Instead, the Session Fixation attack fixes an established session on the victim’s browser, so the attack starts before the user logs in.

Contextual elements:
We were able to control the value of the session cookie. It could lead to session fixation-based attacks. However, because the process requires a valid CSRF token, and a POST request, we couldn’t exploit the vulnerability.
For the session fixation, we first need to get a valid CSRF token. There, we can choose the value of the session cookie associated with the CSRF token.

This PR tackles the following:

Not allowing manual setting of the session id value
Refreshing the session id once the user logs in